### PR TITLE
Allow CORS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ dependencies {
     }
     compile 'org.springframework.hateoas:spring-hateoas:0.19.0.RELEASE'
 
-    compile 'org.eclipse.jetty:jetty-servlets:9.4.0.M0'
+    compile 'org.eclipse.jetty:jetty-servlets:9.2.14.v20151106'
 
     providedCompile 'org.springframework.boot:spring-boot-starter-tomcat:1.3.5.RELEASE'
 

--- a/build.gradle
+++ b/build.gradle
@@ -118,6 +118,8 @@ dependencies {
     }
     compile 'org.springframework.hateoas:spring-hateoas:0.19.0.RELEASE'
 
+    compile 'org.eclipse.jetty:jetty-servlets:9.4.0.M0'
+
     providedCompile 'org.springframework.boot:spring-boot-starter-tomcat:1.3.5.RELEASE'
 
     providedRuntime 'org.hsqldb:hsqldb:2.3.4'

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -13,6 +13,27 @@
         <param-value>/WEB-INF/applicationContext.xml</param-value>
     </context-param>
 
+    <filter>
+        <filter-name>cross-origin</filter-name>
+        <filter-class>org.eclipse.jetty.servlets.CrossOriginFilter</filter-class>
+        <init-param>
+            <param-name>allowedOrigins</param-name>
+            <param-value>*</param-value>
+        </init-param>
+        <init-param>
+            <param-name>allowedMethods</param-name>
+            <param-value>GET,POST,DELETE,PUT,HEAD</param-value>
+        </init-param>
+        <init-param>
+            <param-name>allowedHeaders</param-name>
+            <param-value>origin, content-type, accept</param-value>
+        </init-param>
+    </filter>
+    <filter-mapping>
+        <filter-name>cross-origin</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
     <servlet>
         <servlet-name>appServlet</servlet-name>
         <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>


### PR DESCRIPTION
For this service to be reachable more easily from a browser or a microservice (especially the scheduler-portal), we need to allow cross origin connections.
