### PR TITLE
Custom hibernate to PostgreSQL dialect that properly recognize BLOB type as byte array.

### DIFF
--- a/src/main/java/org/ow2/proactive/workflow_catalog/rest/dialect/PostgreSQLDialect.java
+++ b/src/main/java/org/ow2/proactive/workflow_catalog/rest/dialect/PostgreSQLDialect.java
@@ -1,0 +1,46 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.workflow_catalog.rest.dialect;
+
+import org.hibernate.dialect.PostgreSQL82Dialect;
+import org.hibernate.type.descriptor.sql.BinaryTypeDescriptor;
+import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
+
+
+/**
+ * @author ActiveEon Team
+ * @since 08/06/17
+ */
+public class PostgreSQLDialect extends PostgreSQL82Dialect {
+
+    @Override
+    public SqlTypeDescriptor remapSqlTypeDescriptor(SqlTypeDescriptor sqlTypeDescriptor) {
+        if (sqlTypeDescriptor.getSqlType() == java.sql.Types.BLOB) {
+            return BinaryTypeDescriptor.INSTANCE;
+        }
+        return super.remapSqlTypeDescriptor(sqlTypeDescriptor);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,6 +18,9 @@ server.contextPath=/
 #spring.datasource.username=root
 #spring.datasource.password=
 
+# When relying on a PostgreSQL database, the following hibernate dialect need to be set to properly manage 'BLOB' type
+#hibernate.dialect=org.ow2.proactive.workflow_catalog.rest.dialect.PostgreSQLDialect
+
 # Hibernate ddl auto (create, create-drop, update)
 spring.jpa.hibernate.ddl-auto=update
 


### PR DESCRIPTION
The new class `org.ow2.proactive.workflow_catalog.rest.dialect.PostgreSQLDialect` extends original hibernate `PostgreSQL82Dialect` class and override SQL type descriptor to force BLOB type recognition as a Binary type (`bytea` PostgreSQL type).  

The new dialect must then be specified like this (`application.properties` file):
```
spring.jpa.database-platform=org.ow2.proactive.workflow_catalog.rest.dialect.PostgreSQLDialect
```

This fixes issue #36.